### PR TITLE
Fixed Paint EventListeners 

### DIFF
--- a/rsb/botLauncher/RuneLite.java
+++ b/rsb/botLauncher/RuneLite.java
@@ -53,6 +53,7 @@ import net.runelite.client.rsb.methods.*;
 import net.runelite.client.rsb.internal.InputManager;
 import net.runelite.client.rsb.internal.BotHooks;
 import net.runelite.client.rsb.internal.BotModule;
+import net.runelite.client.rsb.internal.input.Canvas;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.client.ui.FatalErrorDialog;
@@ -308,7 +309,25 @@ public class RuneLite extends net.runelite.client.RuneLite {
         if (client == null) {
             return null;
         }
-        return client.getCanvas();
+        if (client.getCanvas() instanceof java.awt.Canvas) {
+            return new Canvas(client.getCanvas());
+        }
+        return null;
+    }
+
+    public Graphics getBufferGraphics(MainBufferProvider mainBufferProvider) {
+        Graphics back = mainBufferProvider.getImage().getGraphics();
+        paintEvent.graphics = back;
+        textPaintEvent.graphics = back;
+        textPaintEvent.idx = 0;
+        eventManager.processEvent(paintEvent);
+        eventManager.processEvent(textPaintEvent);
+        back.dispose();
+        image.getGraphics().drawImage(backBuffer, 0, 0, null);
+        if (panel != null) {
+            panel.repaint();
+        }
+        return backBuffer.getGraphics();
     }
 
     public Applet getLoader() {

--- a/rsb/gui/BotGUI.java
+++ b/rsb/gui/BotGUI.java
@@ -243,7 +243,7 @@ public class BotGUI extends JFrame implements ActionListener, ScriptListener, Pa
     public RuneLite getBot(Object o) {
         ClassLoader cl = o.getClass().getClassLoader();
         for (RuneLite bot : bots) {
-            if (cl == bot.getClient().getClass().getClassLoader()) {
+            if (cl == bot.getClass().getClassLoader()) {
                 panel.offset();
                 return bot;
             }

--- a/rsb/internal/BotHooks.java
+++ b/rsb/internal/BotHooks.java
@@ -20,7 +20,7 @@ import com.google.inject.Injector;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MainBufferProvider;
-import net.runelite.client.RuneLite;
+import net.runelite.client.rsb.botLauncher.RuneLite;
 import net.runelite.client.callback.Hooks;
 import net.runelite.client.rsb.gui.BotGUI;
 
@@ -42,11 +42,17 @@ public class BotHooks extends Hooks {
     }
 
     Injector injector = RuneLite.getInjector();
-    Client client = injector.getInstance(Client.class);
+    RuneLite bot = injector.getInstance(RuneLite.class);
 
     @Override
     public void draw(MainBufferProvider mainBufferProvider, Graphics graphics, int x, int y) {
         try {
+
+            /*
+            Preferably initialize the value of bot with the current bot on screen
+            IE Application.getBot or similar manner.
+             */
+
 
             if (graphics == null) {
                 return;
@@ -77,23 +83,27 @@ public class BotHooks extends Hooks {
             }
 
             //We then simply invoke the method as needed here. It should perform similar to how it does in RuneLite
-            final Graphics2D graphics2d = (Graphics2D) ((Method) SUPERCLASS_MAP.get(GETGRAPHICS)).invoke(this,
-                    mainBufferProvider);
+            //final Graphics2D graphics2d = (Graphics2D) ((Method) SUPERCLASS_MAP.get(GETGRAPHICS)).invoke(this,
+             //       mainBufferProvider);
+
+            final Graphics2D g2d = (Graphics2D) bot.getCanvas().getGraphics(mainBufferProvider);
 
             // Draw bot overlays
-            BotGUI.paintOverlays(client, graphics2d);
+            BotGUI.paintOverlays(bot.getClient(), g2d);
 
             Image image = mainBufferProvider.getImage();
 
             // Draw the image onto the game canvas
-            graphics.drawImage(image, 0, 0, client.getCanvas());
+            graphics.drawImage(image, 0, 0, bot.getCanvas());
+
 
             // finalImage is backed by the client buffer which will change soon. make a copy
             // so that callbacks can safely use it later from threads.
             // drawManager.processDrawComplete(() -> copy(image));
 
         } catch (Exception e) {
-            log.warn("Bot hooks failed to paint properly");
+            e.printStackTrace();
+            //log.warn("Bot hooks failed to paint properly");
         }
     }
 }

--- a/rsb/internal/input/Canvas.java
+++ b/rsb/internal/input/Canvas.java
@@ -1,5 +1,7 @@
 package net.runelite.client.rsb.internal.input;
 
+import net.runelite.api.MainBufferProvider;
+import net.runelite.client.rsb.botLauncher.Application;
 import net.runelite.client.rsb.botLauncher.RuneLite;
 //import net.runelite.client.Application;
 
@@ -22,15 +24,21 @@ public class Canvas extends java.awt.Canvas {
 	private boolean visible;
 	private boolean focused;
 
-	public Canvas() {
-		init();
-	}
 
 	public Canvas(GraphicsConfiguration c) {
 		super(c);
-		init();
 	}
-/*
+
+	public Canvas(java.awt.Canvas c) {
+		this(c.getGraphicsConfiguration());
+		this.setBounds(c.getBounds());
+		this.setSize(c.getSize());
+		//This may need more variables set in the future
+	}
+
+
+
+
 	@Override
 	public final Graphics getGraphics() {
 		if (bot == null) {
@@ -41,13 +49,30 @@ public class Canvas extends java.awt.Canvas {
 				toshi = true;
 			}
 		}
+		/*
+		We aren't actually controlling the thread
 		try {
 			Thread.sleep(bot.disableCanvas ? DISABLE_GRAPHICS_DELAY : bot.disableRendering ? SLOW_GRAPHICS_DELAY : GRAPHICS_DELAY);
 		} catch (InterruptedException ignored) {
 		}
-		return bot.getBufferGraphics();
+		 */
+
+		return super.getGraphics();//return bot.getBufferGraphics();
 	}
-*/
+
+
+	public final Graphics getGraphics(MainBufferProvider mainBufferProvider) {
+		if (bot == null) {
+			if (toshi) {
+				return super.getGraphics();
+			} else {
+				bot = Application.getBot(this);
+				toshi = true;
+			}
+		}
+		return bot.getBufferGraphics(mainBufferProvider);
+	}
+
 	@Override
 	public final boolean hasFocus() {
 		return focused;
@@ -76,7 +101,9 @@ public class Canvas extends java.awt.Canvas {
 		}
 		return Application.getPanelSize();
 	}
-*/
+
+
+	 */
 	@Override
 	public final void setVisible(boolean visible) {
 		super.setVisible(visible);


### PR DESCRIPTION
Fixed a bad comparison in when getting the bot from the GUI as it would compare the classloader of the client which isn't loaded by the bot.
Fixed the implementation of the PaintEventListeners and others by correcting the cast of Canvas into a new Canvas of ours and then getting the graphics of the Canvas by passing the mainBufferProvider in our BotHooks to it to trigger our drawing methods for the listeners.

This should allow one to create a new listener in a script and add it to the EventManager to draw directly to the screen.